### PR TITLE
Mark IDL interface as exposed in same globals as ML interface

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -27,6 +27,7 @@ partial interface ML {
   ModelLoader createModelLoader();
 };
 
+[SecureContext, Exposed=(Window, DedicatedWorker)]
 interface ModelLoader {
   //TBD
 };

--- a/index.html
+++ b/index.html
@@ -1487,9 +1487,9 @@ Possible extra rowspan handling
 		}
 	}
 </style>
-  <meta content="Bikeshed version 761f52652, updated Tue Oct 5 16:07:23 2021 -0700" name="generator">
+  <meta content="Bikeshed version 0a9ef89b4, updated Mon Nov 8 14:43:16 2021 -0800" name="generator">
   <link href="https://webmachinelearning.github.io/model-loader/" rel="canonical">
-  <meta content="c06b445aa3de97300e83603ac4a6613cebcaaaf1" name="document-revision">
+  <meta content="07f3f1dba1eea644e2362948905e4ce6a4f36293" name="document-revision">
 <style>/* style-autolinks */
 
 .css.css, .property.property, .descriptor.descriptor {
@@ -1988,6 +1988,12 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
 }
 
 @media (prefers-color-scheme: dark) {
+    :root {
+        --dfnpanel-bg: #222;
+        --dfnpanel-text: var(--text);
+    }
+}
+@media (prefers-color-scheme: dark) {
     .highlight:not(.idl) { background: rgba(255, 255, 255, .05); }
 
     c-[a] { color: #d33682 } /* Keyword.Declaration */
@@ -2054,11 +2060,13 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
   <div class="head">
    <p data-fill-with="logo"><a class="logo" href="https://webmachinelearning.github.io/"> <img alt="Logo" height="100" src="https://webmachinelearning.github.io/webmachinelearning-logo.png" width="100"> </a> </p>
    <h1 class="p-name no-ref" id="title">Model Loader API</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="profile-and-date"><span class="content">Draft Community Group Report, <time class="dt-updated" datetime="2021-11-09">9 November 2021</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="profile-and-date"><span class="content">Draft Community Group Report, <time class="dt-updated" datetime="2021-11-10">10 November 2021</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
      <dd><a class="u-url" href="https://webmachinelearning.github.io/model-loader/">https://webmachinelearning.github.io/model-loader/</a>
+     <dt>Issue Tracking:
+     <dd><a href="https://github.com/webmachinelearning/model-loader/issues/">GitHub</a>
      <dt class="editor">Editor:
      <dd class="editor p-author h-card vcard" data-editor-id="114606"><span class="p-name fn">Jonathan Bingham</span> (<a class="p-org org" href="https://google.com">Google Inc.</a>)
      <dt>Explainer:
@@ -2102,6 +2110,7 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
      <a href="#index"><span class="secno"></span> <span class="content">Index</span></a>
      <ol class="toc">
       <li><a href="#index-defined-here"><span class="secno"></span> <span class="content">Terms defined by this specification</span></a>
+      <li><a href="#index-defined-elsewhere"><span class="secno"></span> <span class="content">Terms defined by reference</span></a>
      </ol>
     <li>
      <a href="#references"><span class="secno"></span> <span class="content">References</span></a>
@@ -2119,6 +2128,7 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
   <a data-link-type="idl-name" href="#modelloader" id="ref-for-modelloader"><c- n>ModelLoader</c-></a> <dfn class="idl-code" data-dfn-for="ML" data-dfn-type="method" data-export data-lt="createModelLoader()" id="dom-ml-createmodelloader"><code><c- g>createModelLoader</c-></code><a class="self-link" href="#dom-ml-createmodelloader"></a></dfn>();
 };
 
+[<a class="idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#SecureContext" id="ref-for-SecureContext"><c- g>SecureContext</c-></a>, <a class="idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Exposed" id="ref-for-Exposed"><c- g>Exposed</c-></a>=(<c- n>Window</c->, <c- n>DedicatedWorker</c->)]
 <c- b>interface</c-> <dfn class="dfn-paneled idl-code" data-dfn-type="interface" data-export id="modelloader"><code><c- g>ModelLoader</c-></code></dfn> {
   //TBD
 };
@@ -2191,17 +2201,41 @@ compiledModel<c- p>.</c->compute<c- p>(</c->exampleList<c- p>,</c-> options<c- p
    <li><a href="#dom-ml-createmodelloader">createModelLoader()</a><span>, in § 2</span>
    <li><a href="#modelloader">ModelLoader</a><span>, in § 2</span>
   </ul>
+  <aside class="dfn-panel" data-for="term-for-Exposed">
+   <a href="https://heycam.github.io/webidl/#Exposed">https://heycam.github.io/webidl/#Exposed</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-Exposed">2. API</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-SecureContext">
+   <a href="https://heycam.github.io/webidl/#SecureContext">https://heycam.github.io/webidl/#SecureContext</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-SecureContext">2. API</a>
+   </ul>
+  </aside>
+  <h3 class="no-num no-ref heading settled" id="index-defined-elsewhere"><span class="content">Terms defined by reference</span><a class="self-link" href="#index-defined-elsewhere"></a></h3>
+  <ul class="index">
+   <li>
+    <a data-link-type="biblio">[WebIDL]</a> defines the following terms:
+    <ul>
+     <li><span class="dfn-paneled" id="term-for-Exposed">Exposed</span>
+     <li><span class="dfn-paneled" id="term-for-SecureContext">SecureContext</span>
+    </ul>
+  </ul>
   <h2 class="no-num no-ref heading settled" id="references"><span class="content">References</span><a class="self-link" href="#references"></a></h2>
   <h3 class="no-num no-ref heading settled" id="normative"><span class="content">Normative References</span><a class="self-link" href="#normative"></a></h3>
   <dl>
    <dt id="biblio-rfc2119">[RFC2119]
    <dd>S. Bradner. <a href="https://datatracker.ietf.org/doc/html/rfc2119"><cite>Key words for use in RFCs to Indicate Requirement Levels</cite></a>. March 1997. Best Current Practice. URL: <a href="https://datatracker.ietf.org/doc/html/rfc2119">https://datatracker.ietf.org/doc/html/rfc2119</a>
+   <dt id="biblio-webidl">[WebIDL]
+   <dd>Boris Zbarsky. <a href="https://heycam.github.io/webidl/"><cite>Web IDL</cite></a>. 15 December 2016. ED. URL: <a href="https://heycam.github.io/webidl/">https://heycam.github.io/webidl/</a>
   </dl>
   <h2 class="no-num no-ref heading settled" id="idl-index"><span class="content">IDL Index</span><a class="self-link" href="#idl-index"></a></h2>
 <pre class="idl highlight def"><c- b>partial</c-> <c- b>interface</c-> <a class="idl-code" data-link-type="interface" href="https://webmachinelearning.github.io/webnn/#dom-navigator-ml"><c- g>ML</c-></a> {
   <a data-link-type="idl-name" href="#modelloader"><c- n>ModelLoader</c-></a> <a href="#dom-ml-createmodelloader"><code><c- g>createModelLoader</c-></code></a>();
 };
 
+[<a class="idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#SecureContext"><c- g>SecureContext</c-></a>, <a class="idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Exposed"><c- g>Exposed</c-></a>=(<c- n>Window</c->, <c- n>DedicatedWorker</c->)]
 <c- b>interface</c-> <a href="#modelloader"><code><c- g>ModelLoader</c-></code></a> {
   //TBD
 };


### PR DESCRIPTION
This is needed to make the WebIDL (even if empty) valid, helpful in the context of automating the bikeshed generation in #9


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/webmachinelearning/model-loader/pull/11.html" title="Last updated on Nov 10, 2021, 9:57 AM UTC (51aa9e2)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/webmachinelearning/model-loader/11/07f3f1d...51aa9e2.html" title="Last updated on Nov 10, 2021, 9:57 AM UTC (51aa9e2)">Diff</a>