### PR TITLE
Make the sample code same as our plan in prototype

### DIFF
--- a/explainer.md
+++ b/explainer.md
@@ -36,15 +36,14 @@ const context = await navigator.ml.createContext(
 // input/output nodes are named and can be referenced in the "compute" function.
 loader = new MLModelLoader(context, 
                            { inputs:  {x: 1, y: 2},
-                             outputs: {z: 0 }));
+                             outputs: {z: 0 } });
 // In the first version, we only support loading models from ArrayBuffers. We 
 // believe this covers most of the usage cases. Web developers can download the 
 // model, e.g., by the fetch API. We can add new "load" functions in the future
 // if they are really needed.
 const modelUrl = 'https://path/to/model/file';
 const modelBuffer = await fetch(modelUrl)
-                            .then(response => response.blob())
-                            .then(blob => blob.arrayBuffer());
+                            .then(response => response.arrayBuffer());
 model = await loader.load(modelBuffer);
 // Compute z = f(x,y) where the output buffer is pre-allocated. This is consistent 
 // with the WebNN API and will be good when, for example, the output buffer is a 

--- a/explainer.md
+++ b/explainer.md
@@ -32,10 +32,8 @@ const context = await navigator.ml.createContext(
                                      { devicePreference: "gpu",
                                        powerPreference: "low-power",
                                        modelFormat: "tflite" });
-// Then create the model loader using the MLContext. Notice that, for TFLite 
-// models, users need to specify the indices of the input/output nodes. And the
-// users can optionally give the nodes names then the names can be used to denote 
-// the input/output nodes in the "compute" function.
+// Then create the model loader using the ML context. Notice that the indices for the
+// input/output nodes are named and can be referenced in the "compute" function.
 loader = new MLModelLoader(context, 
                            { inputs:  {x: 1, y: 2},
                              outputs: {z: 0 }));

--- a/explainer.md
+++ b/explainer.md
@@ -32,11 +32,8 @@ const context = await navigator.ml.createContext(
                                      { devicePreference: "gpu",
                                        powerPreference: "low-power",
                                        modelFormat: "tflite" });
-// Then create the model loader using the ML context. Notice that the indices for the
-// input/output nodes are named and can be referenced in the "compute" function.
-loader = new MLModelLoader(context, 
-                           { inputs:  {x: 1, y: 2},
-                             outputs: {z: 0 } });
+// Then create the model loader using the ML context.
+loader = new MLModelLoader(context);
 // In the first version, we only support loading models from ArrayBuffers. We 
 // believe this covers most of the usage cases. Web developers can download the 
 // model, e.g., by the fetch API. We can add new "load" functions in the future
@@ -44,7 +41,11 @@ loader = new MLModelLoader(context,
 const modelUrl = 'https://path/to/model/file';
 const modelBuffer = await fetch(modelUrl)
                             .then(response => response.arrayBuffer());
-model = await loader.load(modelBuffer);
+// Load the model. Notice that the indices for the input/output nodes are named
+// and can be referenced in the "compute" function.
+model = await loader.load(modelBuffer, 
+                            { inputs:  {x: 1, y: 2},
+                              outputs: {z: 0 } });
 // Compute z = f(x,y) where the output buffer is pre-allocated. This is consistent 
 // with the WebNN API and will be good when, for example, the output buffer is a 
 // GPU buffer.


### PR DESCRIPTION
We have decided to make the model loader API consistent with the WebNN API. This leads to significant changes in the API. We also want to offload the work of "model downloading" to users because it will be very easy for them (e.g. using fetch()) but is very complex for us.