### PR TITLE
Add 'default' option to MLDevicePreference and MLPowerPreference

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -40,11 +40,14 @@ API {#api}
 enum MLModelFormat { "tflite" };
 
 enum MLDevicePreference {
+  "default",
   "gpu",
   "cpu"
 };
 
 enum MLPowerPreference {
+  // Let the user agent select the most suitable behavior.
+  "default",
   // Prioritizes execution speed over power consumption.
   "high-performance",
   // Prioritizes power consumption over other considerations such as execution


### PR DESCRIPTION
- To make a sync with WebNN API and to provide easy hand  it needs to be added 'default' option to eum definion for MLDevicePreference, MLPowerPreference